### PR TITLE
feat: update to emojibase v7

### DIFF
--- a/build.js
+++ b/build.js
@@ -63,7 +63,7 @@ async function main () {
                 // TODO: breaking change to allow arrays as well as strings
                 if (Array.isArray(emoji[key])) {
                   // These are usually just variations on the capitalization, with the capitalized version last,
-                  // which in my opinion usually looks best (e.g. "XD" instead of "xD", "XO" instead of "xo"
+                  // which in my opinion usually looks best (e.g. "XD" instead of "xD", "XO" instead of "xo")
                   outEmoji[key] = emoji[key][emoji[key].length - 1]
                 } else {
                   outEmoji[key] = emoji[key]

--- a/build.js
+++ b/build.js
@@ -58,7 +58,7 @@ async function main () {
                 // TODO: breaking change to rename this
                 outEmoji.annotation = emoji[key]
               } else if (key === 'emoticon') {
-                // In case of an array, just take the first string for backwards compat for pre-v7
+                // In case of an array, just take one string for backwards compat for pre-v7
                 // https://github.com/milesj/emojibase/blob/master/packages/data/CHANGELOG.md#700---2021-10-15
                 // TODO: breaking change to allow arrays as well as strings
                 if (Array.isArray(emoji[key])) {

--- a/build.js
+++ b/build.js
@@ -4,10 +4,10 @@ import path from 'path'
 import rimraf from 'rimraf'
 import mkdirp from 'mkdirp'
 
-const IGNORE_FOLDERS = ['meta', 'versions']
+const IGNORE_FOLDERS = ['meta', 'messages', 'versions']
 
 const emojiKeys = new Set([
-  'annotation',
+  'label',
   'emoji',
   'emoticon',
   'group',
@@ -29,12 +29,11 @@ async function main () {
   for (const lang of langs) {
     rimraf.sync(path.resolve('./', lang))
     const shortcodeFiles = fs.readdirSync(path.resolve(emojibaseDir, lang, 'shortcodes'))
+      .filter(_ => _.endsWith('.json'))
     const baseData = JSON.parse(fs.readFileSync(path.resolve(emojibaseDir, lang, 'data.json'), 'utf8'))
     for (const shortcodeFile of shortcodeFiles) {
-      const shortcodeData = JSON.parse(fs.readFileSync(
-        path.resolve(emojibaseDir, lang, 'shortcodes', shortcodeFile),
-        'utf8'
-      ))
+      const fullShortcodeFilename = path.resolve(emojibaseDir, lang, 'shortcodes', shortcodeFile)
+      const shortcodeData = JSON.parse(fs.readFileSync(fullShortcodeFilename, 'utf8'))
 
       const outData = baseData
         .filter(emoji => 'group' in emoji) // skip odd emoji with no group, e.g. regional indicator (1F1E6)
@@ -53,7 +52,23 @@ async function main () {
           // trim keys we don't need
           for (const key of Object.keys(emoji)) {
             if (emojiKeys.has(key)) {
-              if (key === 'skins') {
+              if (key === 'label') {
+                // Rename to annotation for backwards compat for pre-v7
+                // https://github.com/milesj/emojibase/blob/master/packages/data/CHANGELOG.md#700---2021-10-15
+                // TODO: breaking change to rename this
+                outEmoji.annotation = emoji[key]
+              } else if (key === 'emoticon') {
+                // In case of an array, just take the first string for backwards compat for pre-v7
+                // https://github.com/milesj/emojibase/blob/master/packages/data/CHANGELOG.md#700---2021-10-15
+                // TODO: breaking change to allow arrays as well as strings
+                if (Array.isArray(emoji[key])) {
+                  // These are usually just variations on the capitalization, with the capitalized version last,
+                  // which in my opinion usually looks best (e.g. "XD" instead of "xD", "XO" instead of "xo"
+                  outEmoji[key] = emoji[key][emoji[key].length - 1]
+                } else {
+                  outEmoji[key] = emoji[key]
+                }
+              } else if (key === 'skins') {
                 const skins = []
                 for (const skin of emoji.skins) {
                   const outSkin = {}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Nolan Lawson <nolan@nolanlawson.com>",
   "license": "Apache-2.0",
   "devDependencies": {
-    "emojibase-data": "6.2.0",
+    "emojibase-data": "7.0.1",
     "mkdirp": "^1.0.4",
     "rimraf": "^3.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,10 +20,10 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-emojibase-data@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/emojibase-data/-/emojibase-data-6.2.0.tgz#db6c75c36905284fa623f4aa5f468d2be6ed364a"
-  integrity sha512-SWKaXD2QeQs06IE7qfJftsI5924Dqzp+V9xaa5RzZIEWhmlrG6Jt2iKwfgOPHu+5S8MEtOI7GdpKsXj46chXOw==
+emojibase-data@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/emojibase-data/-/emojibase-data-7.0.1.tgz#a81d7fcd12247f7d94a96dcbdb143e6b6dd5c328"
+  integrity sha512-BLZpOdwyFpZ7lzBWyDtnxmKVm/SJMYgAfp1if3o6n1TVUMSXAf0nikONXl90LZuJ/m3XWPBkkubgCet2BsCGGQ==
 
 fs.realpath@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Managed to update to emojibase v7 while maintaining backwards compatibility. Added some TODOs to make breaking changes to break backwards compat, but I don't think it's really important enough to do right now.

In short: `annotation` is now called `label`, and `emoticon` can support an array of strings rather than just one string. The last one is kind of neat, but most of the string arrays are just different capitalizations (e.g. XD and xD), so I don't think it's super important.